### PR TITLE
Update min nodejs version to v22 and add v26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instrumentation-arnavmq",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenTelemetry automatic instrumentation for the `arnavmq` package",
   "main": "dist/src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Bring",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "files": [
     "./dist/src"
@@ -35,7 +35,7 @@
     "@types/amqplib": "^0.10.8",
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/pkginfo": "^0.4.4",
     "arnavmq": "^0.17.2",
     "chai": "^6.2.2",


### PR DESCRIPTION
Node 20 is deprecated, and github actions no longer support it, so the ci runs only with v22 and v24 anyways.